### PR TITLE
Version 15

### DIFF
--- a/LoopbackApp/app/src/main/AndroidManifest.xml
+++ b/LoopbackApp/app/src/main/AndroidManifest.xml
@@ -23,8 +23,8 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.drrickorang.loopback"
 
-    android:versionCode="14"
-    android:versionName="0.9.71">
+    android:versionCode="15"
+    android:versionName="0.9.72">
 
     <uses-permission android:name="android.permission.RECORD_AUDIO"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>

--- a/LoopbackApp/app/src/main/java/org/drrickorang/loopback/Constant.java
+++ b/LoopbackApp/app/src/main/java/org/drrickorang/loopback/Constant.java
@@ -35,6 +35,7 @@ public class Constant {
 
     public static final int BYTES_PER_SHORT = 2;
     public static final int SHORTS_PER_INT = 2;
+    // FIXME Assumes 16-bit and mono, will not work for other bit depths or multi-channel.
     public static final int BYTES_PER_FRAME = 2;    // bytes per sample
 
     // prime numbers that don't overlap with FFT frequencies
@@ -75,7 +76,14 @@ public class Constant {
     public static final int MIN_NUM_CAPTURES = 1;
     public static final int MAX_NUM_CAPTURES = 100;
     public static final int DEFAULT_NUM_CAPTURES = 5;
+    public static final int MIN_IGNORE_FIRST_FRAMES = 0;
+    // impulse happens after 300 ms and shouldn't be ignored
+    public static final int MAX_IGNORE_FIRST_FRAMES = SAMPLING_RATE_MAX * 3 / 10;
+    public static final int DEFAULT_IGNORE_FIRST_FRAMES = 0;
+
 
     // Controls size of pre allocated timestamp arrays
     public static final int MAX_RECORDED_LATE_CALLBACKS_PER_SECOND = 2;
+    // Ignore first few buffer callback periods
+    public static final int BUFFER_PERIOD_DISCARD = 10;
 }

--- a/LoopbackApp/app/src/main/java/org/drrickorang/loopback/GlitchDetectionThread.java
+++ b/LoopbackApp/app/src/main/java/org/drrickorang/loopback/GlitchDetectionThread.java
@@ -16,9 +16,9 @@
 
 package org.drrickorang.loopback;
 
-import java.util.Arrays;
-
 import android.util.Log;
+
+import java.util.Arrays;
 
 
 /**
@@ -213,7 +213,7 @@ public class GlitchDetectionThread extends Thread {
                 // Glitch Detected
                 mGlitches[mGlitchesIndex] = mFFTCount;
                 mGlitchesIndex++;
-                if (mCaptureHolder.isCapturingSysTraces() || mCaptureHolder.isCapturingWavs()) {
+                if (mCaptureHolder.isCapturing()) {
                     checkGlitchConcentration();
                 }
             }

--- a/LoopbackApp/app/src/main/java/org/drrickorang/loopback/LoopbackApplication.java
+++ b/LoopbackApp/app/src/main/java/org/drrickorang/loopback/LoopbackApplication.java
@@ -44,10 +44,12 @@ public class LoopbackApplication extends Application {
     private int mRecorderBuffSizeInBytes = 0; // for both native and java
     private int mAudioThreadType = Constant.AUDIO_THREAD_TYPE_JAVA; //0:Java, 1:Native (JNI)
     private int mMicSource = 3; //maps to MediaRecorder.AudioSource.VOICE_RECOGNITION;
+    private int mIgnoreFirstFrames = 0;
     private int mBufferTestDurationInSeconds = 5;
     private int mBufferTestWavePlotDurationInSeconds = 7;
     private int mNumberOfLoadThreads = 4;
     private boolean mCaptureSysTraceEnabled = false;
+    private boolean mCaptureBugreportEnabled = false;
     private boolean mCaptureWavSnippetsEnabled = false;
     private int mNumStateCaptures = Constant.DEFAULT_NUM_CAPTURES;
 
@@ -175,6 +177,13 @@ public class LoopbackApplication extends Application {
 
     void setMicSource(int micSource) { mMicSource = micSource; }
 
+    int getIgnoreFirstFrames() {
+        return mIgnoreFirstFrames;
+    }
+
+    void setIgnoreFirstFrames(int ignoreFirstFrames) {
+        mIgnoreFirstFrames = ignoreFirstFrames;
+    }
 
     int getPlayerBufferSizeInBytes() {
         return mPlayerBufferSizeInBytes;
@@ -238,12 +247,24 @@ public class LoopbackApplication extends Application {
         mCaptureSysTraceEnabled = enabled;
     }
 
+    public void setCaptureBugreportEnabled(boolean enabled) {
+        mCaptureBugreportEnabled = enabled;
+    }
+
     public void setCaptureWavsEnabled (boolean enabled){
         mCaptureWavSnippetsEnabled = enabled;
     }
 
-    public boolean isCaptureSysTraceEnabled () {
+    public boolean isCaptureEnabled() {
+        return isCaptureSysTraceEnabled() || isCaptureBugreportEnabled();
+    }
+
+    public boolean isCaptureSysTraceEnabled() {
         return mCaptureSysTraceEnabled;
+    }
+
+    public boolean isCaptureBugreportEnabled() {
+        return mCaptureBugreportEnabled;
     }
 
     public int getNumStateCaptures() {

--- a/LoopbackApp/app/src/main/java/org/drrickorang/loopback/PerformanceMeasurement.java
+++ b/LoopbackApp/app/src/main/java/org/drrickorang/loopback/PerformanceMeasurement.java
@@ -107,17 +107,16 @@ public class PerformanceMeasurement {
 
     /**
      * Determine percent of Buffer Period Callbacks that occurred at the expected time
-     * Note: due to current rounding in buffer sampling callbacks occurring at 1 ms after the
-     * expected buffer period are also counted in the returned percentage
      * Returns a value between 0 and 1
      */
     public float percentBufferPeriodsAtExpected() {
         int occurrenceNearExpectedBufferPeriod = 0;
-        // indicate how many beams around mExpectedBufferPeriod do we want to add to the count
-        int numberOfBeams = 2;
-        int start = Math.max(0, mExpectedBufferPeriodMs - numberOfBeams);
-        int end = Math.min(mBufferData.length, mExpectedBufferPeriodMs + numberOfBeams);
-        for (int i = start; i < end; i++) {
+        // indicate how many buckets around mExpectedBufferPeriod do we want to add to the count
+        int acceptableOffset = 2;
+        int start = Math.max(0, mExpectedBufferPeriodMs - acceptableOffset);
+        int end = Math.min(mBufferData.length - 1, mExpectedBufferPeriodMs + acceptableOffset);
+        // include the next bucket too because the period is rounded up
+        for (int i = start; i <= end; i++) {
             occurrenceNearExpectedBufferPeriod += mBufferData[i];
         }
         return ((float) occurrenceNearExpectedBufferPeriod) / mTotalOccurrence;

--- a/LoopbackApp/app/src/main/java/org/drrickorang/loopback/SettingsActivity.java
+++ b/LoopbackApp/app/src/main/java/org/drrickorang/loopback/SettingsActivity.java
@@ -23,12 +23,12 @@ import android.util.Log;
 import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.AdapterView;
+import android.widget.AdapterView.OnItemSelectedListener;
+import android.widget.ArrayAdapter;
 import android.widget.CompoundButton;
 import android.widget.PopupWindow;
 import android.widget.Spinner;
-import android.widget.ArrayAdapter;
-import android.widget.AdapterView.OnItemSelectedListener;
-import android.widget.AdapterView;
 import android.widget.TextView;
 import android.widget.ToggleButton;
 
@@ -53,7 +53,9 @@ public class SettingsActivity extends Activity implements OnItemSelectedListener
     private SettingsPicker mWavePlotDurationUI;
     private SettingsPicker mLoadThreadUI;
     private SettingsPicker mNumCapturesUI;
+    private SettingsPicker mIgnoreFirstFramesUI;
     private ToggleButton   mSystraceToggleButton;
+    private ToggleButton   mBugreportToggleButton;
     private ToggleButton   mWavCaptureToggleButton;
 
     ArrayAdapter<CharSequence> mAdapterSamplingRate;
@@ -220,9 +222,28 @@ public class SettingsActivity extends Activity implements OnItemSelectedListener
         mWavCaptureToggleButton.setChecked(getApp().isCaptureWavSnippetsEnabled());
         mWavCaptureToggleButton.setOnCheckedChangeListener(this);
 
+        mBugreportToggleButton = (ToggleButton) findViewById(R.id.BugreportEnabledToggle);
+        mBugreportToggleButton.setChecked(getApp().isCaptureBugreportEnabled());
+        mBugreportToggleButton.setOnCheckedChangeListener(this);
+
         mSystraceToggleButton = (ToggleButton) findViewById(R.id.SystraceEnabledToggle);
         mSystraceToggleButton.setChecked(getApp().isCaptureSysTraceEnabled());
         mSystraceToggleButton.setOnCheckedChangeListener(this);
+
+        // Settings Picker for number of frames to ignore at the beginning
+        mIgnoreFirstFramesUI = (SettingsPicker) findViewById(R.id.ignoreFirstFramesSettingPicker);
+        mIgnoreFirstFramesUI.setMinMaxDefault(Constant.MIN_IGNORE_FIRST_FRAMES,
+                Constant.MAX_IGNORE_FIRST_FRAMES, getApp().getIgnoreFirstFrames());
+        mIgnoreFirstFramesUI.setTitle(getResources().getString(R.string.labelIgnoreFirstFrames,
+                Constant.MAX_IGNORE_FIRST_FRAMES));
+        mIgnoreFirstFramesUI.setSettingsChangeListener(new SettingsPicker.SettingChangeListener() {
+            @Override
+            public void settingChanged(int frames) {
+                log("new number of first frames to ignore: " + frames);
+                getApp().setIgnoreFirstFrames(frames);
+                setSettingsHaveChanged();
+            }
+        });
 
         refresh();
     }
@@ -266,7 +287,7 @@ public class SettingsActivity extends Activity implements OnItemSelectedListener
             mSpinnerChannelIndex.setEnabled(false);
         }
 
-        mNumCapturesUI.setEnabled(getApp().isCaptureSysTraceEnabled() ||
+        mNumCapturesUI.setEnabled(getApp().isCaptureEnabled() ||
                 getApp().isCaptureWavSnippetsEnabled());
 
         String info = getApp().getSystemInfo();
@@ -319,8 +340,10 @@ public class SettingsActivity extends Activity implements OnItemSelectedListener
             getApp().setCaptureWavsEnabled(isChecked);
         } else if (buttonView.getId() == mSystraceToggleButton.getId()) {
             getApp().setCaptureSysTraceEnabled(isChecked);
+        } else if (buttonView.getId() == mBugreportToggleButton.getId()) {
+            getApp().setCaptureBugreportEnabled(isChecked);
         }
-        mNumCapturesUI.setEnabled(getApp().isCaptureSysTraceEnabled() ||
+        mNumCapturesUI.setEnabled(getApp().isCaptureEnabled() ||
                 getApp().isCaptureWavSnippetsEnabled());
     }
 

--- a/LoopbackApp/app/src/main/jni/audio_utils/atomic.c
+++ b/LoopbackApp/app/src/main/jni/audio_utils/atomic.c
@@ -17,6 +17,7 @@
 #include "atomic.h"
 
 #include <stdatomic.h>
+#include <stdbool.h>
 
 int32_t android_atomic_acquire_load(volatile const int32_t* addr) {
     volatile atomic_int_least32_t* a = (volatile atomic_int_least32_t*) addr;
@@ -26,4 +27,14 @@ int32_t android_atomic_acquire_load(volatile const int32_t* addr) {
 void android_atomic_release_store(int32_t value, volatile int32_t* addr) {
     volatile atomic_int_least32_t* a = (volatile atomic_int_least32_t*) addr;
     atomic_store_explicit(a, value, memory_order_release);
+}
+
+int32_t android_atomic_exchange(int32_t value, volatile const int32_t* addr) {
+    volatile atomic_int_least32_t* a = (volatile atomic_int_least32_t*) addr;
+    return atomic_exchange(a, value);
+}
+
+bool android_atomic_compare_exchange(int32_t* expect, int32_t desire, volatile const int32_t* addr) {
+    volatile atomic_int_least32_t* a = (volatile atomic_int_least32_t*) addr;
+    return atomic_compare_exchange_weak(a, expect, desire);
 }

--- a/LoopbackApp/app/src/main/jni/audio_utils/atomic.h
+++ b/LoopbackApp/app/src/main/jni/audio_utils/atomic.h
@@ -18,6 +18,7 @@
 #define ANDROID_AUDIO_ATOMIC_H
 
 #include <stdlib.h>
+#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -25,6 +26,10 @@ extern "C" {
 
 int32_t android_atomic_acquire_load(volatile const int32_t* addr);
 void android_atomic_release_store(int32_t value, volatile int32_t* addr);
+
+// FIXME: use standard atomic library instead of these functions
+int32_t android_atomic_exchange(int32_t value, volatile const int32_t* addr);
+bool android_atomic_compare_exchange(int32_t* expect, int32_t desire, volatile const int32_t* addr);
 
 #ifdef __cplusplus
 }

--- a/LoopbackApp/app/src/main/jni/jni_sles.h
+++ b/LoopbackApp/app/src/main/jni/jni_sles.h
@@ -27,7 +27,7 @@ extern "C" {
 ////SLE
 JNIEXPORT jlong JNICALL Java_org_drrickorang_loopback_NativeAudioThread_slesInit
   (JNIEnv *, jobject, jint, jint, jint, jint, jdouble, jobject byteBuffer,
-       jshortArray loopbackTone, jint maxRecordedLateCallbacks, jobject captureHolder);
+   jshortArray loopbackTone, jint maxRecordedLateCallbacks, jint ignoreFirstFrames);
 
 JNIEXPORT jint JNICALL Java_org_drrickorang_loopback_NativeAudioThread_slesProcessNext
   (JNIEnv *, jobject, jlong, jdoubleArray, jlong);
@@ -43,11 +43,24 @@ JNIEXPORT jint JNICALL
         Java_org_drrickorang_loopback_NativeAudioThread_slesGetRecorderMaxBufferPeriod
   (JNIEnv *, jobject, jlong);
 
+JNIEXPORT jdouble JNICALL
+        Java_org_drrickorang_loopback_NativeAudioThread_slesGetRecorderVarianceBufferPeriod
+  (JNIEnv *, jobject, jlong);
+
 JNIEXPORT jintArray JNICALL
         Java_org_drrickorang_loopback_NativeAudioThread_slesGetPlayerBufferPeriod
   (JNIEnv *, jobject, jlong);
 
-JNIEXPORT jint JNICALL Java_org_drrickorang_loopback_NativeAudioThread_slesGetPlayerMaxBufferPeriod
+JNIEXPORT jint JNICALL
+        Java_org_drrickorang_loopback_NativeAudioThread_slesGetPlayerMaxBufferPeriod
+  (JNIEnv *, jobject, jlong);
+
+JNIEXPORT jdouble JNICALL
+        Java_org_drrickorang_loopback_NativeAudioThread_slesGetPlayerVarianceBufferPeriod
+  (JNIEnv *, jobject, jlong);
+
+JNIEXPORT jint JNICALL
+        Java_org_drrickorang_loopback_NativeAudioThread_slesGetCaptureRank
   (JNIEnv *, jobject, jlong);
 
 #ifdef __cplusplus

--- a/LoopbackApp/app/src/main/res/layout/settings_activity.xml
+++ b/LoopbackApp/app/src/main/res/layout/settings_activity.xml
@@ -223,6 +223,51 @@
                     android:layout_height="match_parent"
                     android:layout_weight="3">
                     <ToggleButton
+                        android:id="@+id/BugreportEnabledToggle"
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:layout_marginRight="15dp"
+                        android:background="@drawable/togglebutton_state_drawable"
+                        android:textOn="Enabled"
+                        android:textOff="Disabled"/>
+                </RelativeLayout>
+                <RelativeLayout
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_weight="6">
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/enableBugreport"/>
+                </RelativeLayout>
+                <RelativeLayout
+                    android:layout_width="0dip"
+                    android:layout_height="match_parent"
+                    android:layout_weight="1">
+                    <ImageView
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:onClick="onButtonSysTraceHelp"
+                        android:src="@drawable/ic_help_outline"/>
+                </RelativeLayout>
+            </LinearLayout>
+
+            <View
+                android:layout_width="fill_parent"
+                android:layout_height="1dp"
+                android:background="@android:color/darker_gray"/>
+
+            <LinearLayout
+                android:orientation="horizontal"
+                android:layout_width="match_parent"
+                android:layout_height="80dp"
+                android:padding="15dp">
+
+                <RelativeLayout
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_weight="3">
+                    <ToggleButton
                         android:id="@+id/wavSnippetsEnabledToggle"
                         android:layout_width="match_parent"
                         android:layout_height="match_parent"
@@ -255,6 +300,16 @@
 
             <org.drrickorang.loopback.SettingsPicker
                 android:id="@+id/numCapturesSettingPicker"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"/>
+
+            <View
+                android:layout_width="fill_parent"
+                android:layout_height="1dp"
+                android:background="@android:color/darker_gray"/>
+
+            <org.drrickorang.loopback.SettingsPicker
+                android:id="@+id/ignoreFirstFramesSettingPicker"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"/>
 

--- a/LoopbackApp/app/src/main/res/raw/loopback_listener
+++ b/LoopbackApp/app/src/main/res/raw/loopback_listener
@@ -41,19 +41,27 @@ do
         # Ensure that if more than one listener is running only one will consume signal
         > $SIGNAL_FILE
 
-        if [ $contents == $TERMINATE_SIGNAL ]
+        if [ "$contents" == $TERMINATE_SIGNAL ]
         then
             exitListener
         else
-            # write Systrace and bugreport to files
+            for filename in $contents
+            do
+                case $filename in
+                *$SYSTRACE_SUFFIX)
+                    echo "LOOPBACK LISTENER: dumping systrace to file $filename"
+                    atrace --async_dump -z -c -b $BUFFER_KB $TRACE_CATEGORIES > $filename
+                    ;;
 
-            echo "LOOPBACK LISTENER: dumping systrace to file $contents$SYSTRACE_SUFFIX"
-            atrace --async_dump -z -c -b $BUFFER_KB $TRACE_CATEGORIES > $contents$SYSTRACE_SUFFIX
+                *$BUGREPORT_SUFFIX)
+                    echo "LOOPBACK LISTENER: dumping bugreport to file $filename"
+                    bugreport | gzip > $filename
+                    ;;
 
-            echo "LOOPBACK LISTENER: dumping bugreport to file $contents$BUGREPORT_SUFFIX"
-            bugreport | gzip > $contents$BUGREPORT_SUFFIX
+                esac
+            done
 
-            echo "LOOPBACK LISTENER: Finished systrace and bugreport"
+            echo "LOOPBACK LISTENER: Finished capture"
 
             # Check for case that test has ended while capturing state and exit
             if [ -e "$SIGNAL_FILE" ] && [ -s "$SIGNAL_FILE" ] \

--- a/LoopbackApp/app/src/main/res/values/strings.xml
+++ b/LoopbackApp/app/src/main/res/values/strings.xml
@@ -136,10 +136,13 @@
     <string name="labelBufferTestWavePlotDuration">Buffer Test Wave Plot Duration (Seconds)
                                                    (Max: %1$d)</string>
     <string name="loadThreadsLabel">Number of Simulated Load Threads</string>
-    <string name="enableSystrace">Systrace and BugReport Captures During Test</string>
+    <string name="enableSystrace">Systrace Captures During Test</string>
+    <string name="enableBugreport">BugReport Captures During Test</string>
     <string name="enableWavSnippets">Wav Snippet Captures During Test</string>
     <string name="numCapturesSetting">Number of Systrace/BugReport and or Wav Snippets to Capture
     </string>
+    <string name="labelIgnoreFirstFrames">
+        Frames to ignore at the start of the latency test (Max: %1$d)</string>
 
     <string name="SaveFileDialogLabel">Save Files To:</string>
     <string name="SaveFileDialogOK">//mnt/sdcard/</string>


### PR DESCRIPTION
Snap to commit 1265b7e83b43ebc8227d9243591914ea0721cec4

Allow enabling systrace and bugreport captures separately in LoopbackApp.
Capturing a bugreport takes a lot of time and CPU power. The CPU usage
may cause another glitch, or an unrelated glitch may be missed because
the app is waiting for a bugreport to complete.

Capture systrace/bugreport on late callbacks in LoopbackApp.

Remove obsolete method for systrace from native code in LoopbackApp.
The code for this was unused.

Add more atomic methods to audio_utils in LoopbackApp.
Note that these methods are temporary until we can move to the standard
atomic library for C++.

Discard player callbacks if recorder is not yet running.

Display channelIndex in LoopbackApp as MONO when appropriate.

Iteratively calculate variance in LoopbackApp for Java.

Iteratively calculate variance in LoopbackApp for native only.
It is converted into standard deviation and reported by the app.

Refactor statistics recording into a new function in LoopbackApp.
This will make it easier to add new metrics and adjust the existing ones.

Deduplicate code dealing with buffer period stats in LoopbackApp.
Previously, the code for the recorder and player was copied and pasted
with minimal changes.

Fix build warning.

Refactor LoopbackApp buffer stats into one struct.
By unifying the player and recorder stats, copy-pasted code can be
eliminated and adding new statistics is made much easier.

Fix how late buffer callbacks are counted in LoopbackApp.
The previous calculation id not take rounding into account which causes
it to incorrectly label callbacks which occured only 1 ms late as over
the threshold of 2 ms late. This results in the metric being
oversensitive and flaky.

Add setting to LoopbackApp to ignore beginning of recording.
This is useful to work around hardware bugs that cause pops or other
noise at the beginning of a recording.
